### PR TITLE
fix missing leading 0

### DIFF
--- a/WebApp/src/context/GlobalState.tsx
+++ b/WebApp/src/context/GlobalState.tsx
@@ -85,7 +85,8 @@ const GlobalState: React.FC<PropsWithChildren> = ({ children }) => {
       const hours = now.getHours().toString().padStart(2, '0');
       const minutes = now.getMinutes().toString().padStart(2, '0');
       const seconds = now.getSeconds().toString().padStart(2, '0');
-      setCurrentTime(`${+hours <= 12 ? hours : +hours - 12}:${minutes}:${seconds}`);
+      
+      setCurrentTime(`${+hours <= 12 ? hours : (+hours - 12).toString().padStart(2, '0') }:${minutes}:${seconds} ${+hours < 12 ? "AM" : "PM" }`);
 
       // so it updates the date every day without having to refresh the page
       const formattedDate = now.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' });


### PR DESCRIPTION
Tyler, 
Original code 
```js
setCurrentTime(`${+hours <= 12 ? hours : +hours - 12}:${minutes}:${seconds}`);
```
was converting the hour into a number ` +hours - 12`, removing leading 0. But we forgot to put the leading zeros back. 

Also added AM/PM. 